### PR TITLE
Modified sample_pixel to read ds9 regions file

### DIFF
--- a/CubeLineMoment.py
+++ b/CubeLineMoment.py
@@ -636,6 +636,8 @@ def pyspeckit_fit_cube(cube, max_map, centroid_map, width_map, noisemap,
 def parse_floatlist(flist):
     if ',' in flist:
         return list(map(float, flist.split(", ")))
+    elif isinstance(flist, list):
+        return flist
     else:
         return [float(flist)]
 

--- a/CubeLineMoment.py
+++ b/CubeLineMoment.py
@@ -638,7 +638,7 @@ def parse_floatlist(flist):
         if ',' in flist:
             return list(map(float, flist.split(", ")))
         elif isinstance(flist, list):
-            return flist
+            return list(map(float, flist))
         else:
             return [float(flist)]
     except:

--- a/CubeLineMoment.py
+++ b/CubeLineMoment.py
@@ -634,12 +634,16 @@ def pyspeckit_fit_cube(cube, max_map, centroid_map, width_map, noisemap,
 
 
 def parse_floatlist(flist):
-    if ',' in flist:
-        return list(map(float, flist.split(", ")))
-    elif isinstance(flist, list):
-        return flist
-    else:
-        return [float(flist)]
+    try:
+        if ',' in flist:
+            return list(map(float, flist.split(", ")))
+        elif isinstance(flist, list):
+            return flist
+        else:
+            return [float(flist)]
+    except:
+        print(flist)
+        raise
 
 def main():
     """


### PR DESCRIPTION
Since sample_position required knowing what the pixel position of the desired sample position was in the cutout cube, which one would not necessarily have before running CubeLineMoment, thought it useful to be able to read an (RA,Dec) position for sample_pixel from a ds9 file.  CubeLineMoment now also extracts the label meta variable and uses it in the titles for the diagnostic plots.

Note, though, that I really do not like the way I solved this problem, as I had to read-in the cutoutcube in order to access its WCS information so that I could turn the (RA,Dec) from the ds9 file into a pixel coordinate.  This extra FITS file read noticeably slows the script down.  I am sure that @keflavich has a slicker way to get at the WCS information.