### PR TITLE
Addresses Issue #6: Allow for "Brightest Line Cube" that is different than Target Cube

### DIFF
--- a/CubeLineMoment.py
+++ b/CubeLineMoment.py
@@ -232,8 +232,8 @@ def cubelinemoment_setup(cube, cuberegion, cutoutcube,
 
     # Create noisemapbright_baseline mask for plotting
     brightbaseline_mask = np.zeros_like(inds, dtype='bool')
-    for i in range(len(noisemapbright_baseline)):
-        brightbaseline_mask[noisemapbright_baseline[i][0]:noisemapbright_baseline[i][1]] = True
+    for lo, hi in noisemapbright_baseline:
+        brightbaseline_mask[lo:hi] = True
     
     # Make a plot of the noise map...
     #pl.figure(2).clf()

--- a/CubeLineMomentManual.md
+++ b/CubeLineMomentManual.md
@@ -27,7 +27,7 @@ To run in ipython use:
 
 **cuberegion [string]:** ds9 region file used to spatial mask for input FITS cube emission region. Example: regions/NGC253BoxBand6H2COJ32K02.reg
 
-**cutoutcube [string]:** Input FITS cube which contains "tracer" transition which is strong and representative of dense gas emission region traced by other molecules/transitions in cube. Example: FITS/NGC253-H213COJ32K1-Feather-line.fits
+**cutoutcube [string]:** Input FITS cube which contains "tracer" transition which is strong and representative of dense gas emission region traced by other molecules/transitions in cube. Note that this cube can be any image cube, as long as the PPV range overlaps with cuberegion.  Example: FITS/NGC253-H213COJ32K1-Feather-line.fits
 
 **cutoutcuberegion [string]:** ds9 region file used to spatial mask input FITS spatialmaskcube. Example: regions/NGC253BoxBand6H2COJ32K02.reg
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ YAML File Input Parameters:
 
  - cutoutcube [string]: Input FITS cube which contains "tracer"
    transition which is strong and representative of dense gas emission
-   region traced by other molecules/transitions in cube.
+   region traced by other molecules/transitions in cube.  Note that this
+   cube can be any image cube, as long as the PPV range overlaps with cuberegion.
    Example: FITS/NGC253-H213COJ32K1-Feather-line.fits
 
  - cutoutcuberegion [string]: ds9 region file used to spatial


### PR DESCRIPTION
No significant changes to script for this change.  Only tested on image cube with same PPV structure (i.e. both `cube` and 'cutoutcube` are from ALCHEMI).  Cube was HCN 1-0 while `cutoutcube` was 13CO 2-1.  Updated `README.md` and 'CubeLineMomentManual.md` also.  Also changed variable name `noisecube` to `noisecubebright` to (hopefully) avoid confusion.  Note also that includes new `brightest_line_name` parameter in yaml file, but this has more to do with a pending upgrade to the diagnostic plotting and header information.